### PR TITLE
Added additional subdomain .prod. to the URL prior to AWS go live

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ pipeline:
       - KUBE_NAMESPACE=dq-management
       - INSECURE_SKIP_TLS_VERIFY=true
       - JIRA_HOME_VOLUME_SIZE=25Gi
-      - HOSTNAME=jira.dq.homeoffice.gov.uk
+      - HOSTNAME=jira.prod.dq.homeoffice.gov.uk
     commands:
       - export KUBE_TOKEN=$$PROD_KUBE_TOKEN
       - export KUBE_SERVER=$$PROD_KUBE_SERVER

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# dq-kube-jira
+# Deploying JIRA in Docker on ACP
+
+## Deployment
+
+This project is expected to be used to deploy in the UK Home Office ACP and
+therefore depends on certain features present in the platform.
+
+### Additional manual steps
+
+To get JIRA to work correctly with the proxy, the `server.xml` file needs to be
+overwritten with the version in this repository. To do this deploy the container
+and use `kubectl cp` to transfer the file on to the running container.
+
+```
+kubectl cp jira-conf/server.xml <jira pod id>:/opt/atlassian/jira/conf/server.xml -c jira
+```


### PR DESCRIPTION
The prod version can't deploy as the hostname is invalid due to the subdomain still being pointed at the legacy data centre.

Also updated the readme with additional deployment instructions.